### PR TITLE
Fix compilation issues in kill tracker and behavior

### DIFF
--- a/TorNecroQoL/TNQ_PlayerKillTracker.cs
+++ b/TorNecroQoL/TNQ_PlayerKillTracker.cs
@@ -1,4 +1,5 @@
 // TNQ_PlayerKillTracker.cs
+using TaleWorlds.Core;
 using TaleWorlds.MountAndBlade;
 using TaleWorlds.CampaignSystem;
 
@@ -53,7 +54,7 @@ namespace TorNecroQoL
             }
         }
 
-        public override void OnMissionEnded()
+        public override void OnEndMission()
         {
             TNQ_KillSnapshot.LastMissionPlayerKills = _playerKills;
         }

--- a/TorNecroQoL/TorNecroQoLBehavior.cs
+++ b/TorNecroQoL/TorNecroQoLBehavior.cs
@@ -20,7 +20,7 @@ namespace TorNecroQoL
     public sealed class TorNecroQoLBehavior : CampaignBehaviorBase
     {
         // enable to print exact gates that block graveyard raising
-        private const bool DEBUG_RAISE_DIAGNOSTICS = false;
+        private static readonly bool DEBUG_RAISE_DIAGNOSTICS = false;
         private bool _graveyardPatched;
         private Delegate _torOriginalRaiseConsequence;
 


### PR DESCRIPTION
## Summary
- import TaleWorlds.Core in the kill tracker so AgentState resolves
- update the mission cleanup override to the current API name
- adjust debug flag to avoid unreachable-code warnings in the behavior

## Testing
- not run (per instructions)

------
https://chatgpt.com/codex/tasks/task_e_68d492a20e40832090311f4ff5a13485