### PR TITLE
Fix player kill tracker build issues

### DIFF
--- a/TorNecroQoL/TNQ_PlayerKillTracker.cs
+++ b/TorNecroQoL/TNQ_PlayerKillTracker.cs
@@ -46,7 +46,7 @@ namespace TorNecroQoL
                 _playerKills++;
                 return;
             }
-            var hero = killer.Character?.HeroObject;
+            var hero = (killer.Character as CharacterObject)?.HeroObject;
             if (hero != null && ReferenceEquals(hero, Hero.MainHero))
             {
                 if (affected.Team != null && killer.Team != null && !affected.Team.IsEnemyOf(killer.Team)) return;
@@ -54,7 +54,7 @@ namespace TorNecroQoL
             }
         }
 
-        public override void OnEndMission()
+        protected override void OnEndMission()
         {
             TNQ_KillSnapshot.LastMissionPlayerKills = _playerKills;
         }

--- a/TorNecroQoL/TorNecroQoL.csproj
+++ b/TorNecroQoL/TorNecroQoL.csproj
@@ -75,6 +75,9 @@
     <Reference Include="TaleWorlds.MountAndBlade">
       <HintPath>D:\Spiele\Mount and Blade II Bannerlord\bin\Win64_Shipping_Client\TaleWorlds.MountAndBlade.dll</HintPath>
     </Reference>
+    <Reference Include="TaleWorlds.DotNet">
+      <HintPath>D:\Spiele\Mount and Blade II Bannerlord\bin\Win64_Shipping_Client\TaleWorlds.DotNet.dll</HintPath>
+    </Reference>
     <Reference Include="TaleWorlds.ObjectSystem">
       <HintPath>D:\Spiele\Mount and Blade II Bannerlord\bin\Win64_Shipping_Client\TaleWorlds.ObjectSystem.dll</HintPath>
     </Reference>


### PR DESCRIPTION
## Summary
- cast agent character to CharacterObject before accessing HeroObject in the kill tracker
- ensure the mission end override keeps the inherited protected visibility
- add the TaleWorlds.DotNet assembly reference required by the kill tracker

## Testing
- not run (per instructions)


------
https://chatgpt.com/codex/tasks/task_e_68d4954e84408320950a123858620097