### PR TITLE
Expand kill tracker logging and KO counting

### DIFF
--- a/TorNecroQoL/TNQ_PlayerKillTracker.cs
+++ b/TorNecroQoL/TNQ_PlayerKillTracker.cs
@@ -12,18 +12,20 @@ namespace TorNecroQoL
 
     internal sealed class TNQ_PlayerKillTracker : MissionBehavior
     {
+        private const bool DEBUG_PK = true;
         private int _playerKills;
 
         public override void OnBehaviorInitialize()
         {
             _playerKills = 0;
+            if (DEBUG_PK) Logger.Info("[TNQ] KillTracker attached");
         }
 
         public override void OnAgentRemoved(Agent affected, Agent affector, AgentState state, KillingBlow blow)
         {
             if (affected == null) return;
             // count only hard kills (not KOs/despawns) and only vs enemies & humans
-            if (state != AgentState.Killed) return;
+            if (state != AgentState.Killed && state != AgentState.Unconscious) return;
             if (!affected.IsHuman) return;
 
             // resolve killer: mount trample -> attribute to rider
@@ -44,6 +46,7 @@ namespace TorNecroQoL
                 // avoid friendly fire counting
                 if (affected.Team != null && killer.Team != null && !affected.Team.IsEnemyOf(killer.Team)) return;
                 _playerKills++;
+                if (DEBUG_PK) Logger.Info($"[TNQ] +1 ({state}) by player; total={_playerKills}");
                 return;
             }
             var hero = (killer.Character as CharacterObject)?.HeroObject;
@@ -51,6 +54,7 @@ namespace TorNecroQoL
             {
                 if (affected.Team != null && killer.Team != null && !affected.Team.IsEnemyOf(killer.Team)) return;
                 _playerKills++;
+                if (DEBUG_PK) Logger.Info($"[TNQ] +1 ({state}) by Hero.MainHero; total={_playerKills}");
             }
         }
 


### PR DESCRIPTION
## Summary
- count both AgentState.Killed and AgentState.Unconscious events in the kill tracker so Bannerlord KOs are credited
- add a DEBUG_PK switch that logs tracker attachment and each qualifying kill for the player or main hero

## Testing
- not run (per instructions)

------
https://chatgpt.com/codex/tasks/task_e_68d4984357608320a74a48bb33539b24